### PR TITLE
Fix BigQuery SQL FROM statement typos

### DIFF
--- a/backends/bigquery/sql/1_01_login_highly_privileged_account.sql
+++ b/backends/bigquery/sql/1_01_login_highly_privileged_account.sql
@@ -20,7 +20,7 @@ SELECT
   protopayload_auditlog.methodName,
   protopayload_auditlog.requestMetadata.callerIp,
   JSON_EXTRACT(protopayload_auditlog.metadataJson, "$.event[0].parameter[0].value") AS loginType
-FROM `[MY_DATASET_ID].[MY_PROJECT_ID].cloudaudit_googleapis_com_data_access`
+FROM `[MY_PROJECT_ID].[MY_DATASET_ID].cloudaudit_googleapis_com_data_access`
 WHERE
   timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
   AND protopayload_auditlog.authenticationInfo.principalEmail LIKE "admin%"

--- a/backends/bigquery/sql/1_03_excessive_login_failures.sql
+++ b/backends/bigquery/sql/1_03_excessive_login_failures.sql
@@ -20,7 +20,7 @@ SELECT
   MAX(timestamp) AS latest,
   count(*) AS attempts
 FROM
- `[MY_DATASET_ID].[MY_PROJECT_ID].cloudaudit_googleapis_com_data_access`
+ `[MY_PROJECT_ID].[MY_DATASET_ID].cloudaudit_googleapis_com_data_access`
 WHERE
   timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
   AND protopayload_auditlog.serviceName="login.googleapis.com"

--- a/backends/bigquery/sql/1_10_access_attempts_blocked_by_VPC_SC.sql
+++ b/backends/bigquery/sql/1_10_access_attempts_blocked_by_VPC_SC.sql
@@ -31,7 +31,7 @@ SELECT
     JSON_VALUE(protopayload_auditlog.metadataJson, '$.egressViolations[0].servicePerimeter')
   ) AS  servicePerimeter
 FROM
- `[MY_DATASET_ID].[MY_PROJECT_ID].cloudaudit_googleapis_com_policy`
+ `[MY_PROJECT_ID].[MY_DATASET_ID].cloudaudit_googleapis_com_policy`
 WHERE
   timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 400 DAY)
   AND JSON_VALUE(protopayload_auditlog.metadataJson, '$."@type"') = 'type.googleapis.com/google.cloud.audit.VpcServiceControlAuditMetadata'

--- a/backends/bigquery/sql/1_20_access_attempts_blocked_by_IAP.sql
+++ b/backends/bigquery/sql/1_20_access_attempts_blocked_by_IAP.sql
@@ -21,7 +21,7 @@ SELECT
   httpRequest.status,
   resource.labels.backend_service_name,
   httpRequest.requestUrl,
-FROM `[MY_DATASET_ID].[MY_PROJECT_ID].requests`
+FROM `[MY_PROJECT_ID].[MY_DATASET_ID].requests`
 WHERE
   timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
   AND resource.type="http_load_balancer"

--- a/backends/bigquery/sql/6_20_connections_blocked_by_cloud_armor.sql
+++ b/backends/bigquery/sql/6_20_connections_blocked_by_cloud_armor.sql
@@ -21,7 +21,7 @@ SELECT
   httpRequest.status,jsonpayload_type_loadbalancerlogentry.enforcedsecuritypolicy.name,
   resource.labels.backend_service_name,
   httpRequest.requestUrl,
-FROM `[MY_DATASET_ID].[MY_PROJECT_ID].requests`
+FROM `[MY_PROJECT_ID].[MY_DATASET_ID].requests`
 WHERE
   timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
   AND resource.type="http_load_balancer"

--- a/backends/bigquery/sql/6_21_log4j_exploit_attempts.sql
+++ b/backends/bigquery/sql/6_21_log4j_exploit_attempts.sql
@@ -16,7 +16,7 @@
 
 SELECT
   *
-FROM `[MY_DATASET_ID].[MY_PROJECT_ID].requests`
+FROM `[MY_PROJECT_ID].[MY_DATASET_ID].requests`
 WHERE
   timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
   AND resource.type="http_load_balancer"

--- a/backends/bigquery/sql/6_22_log4j_exploit_attempts_remote_IP_address_list.sql
+++ b/backends/bigquery/sql/6_22_log4j_exploit_attempts_remote_IP_address_list.sql
@@ -21,7 +21,7 @@ SELECT
   ARRAY_AGG(DISTINCT httpRequest.status) AS statuses,
   ARRAY_AGG(DISTINCT jsonpayload_type_loadbalancerlogentry.statusdetails) AS statusdetails,
   COUNT(*) AS counter
-FROM `[MY_DATASET_ID].[MY_PROJECT_ID].requests`
+FROM `[MY_PROJECT_ID].[MY_DATASET_ID].requests`
 WHERE
   timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 30 DAY)
   AND resource.type="http_load_balancer"

--- a/backends/bigquery/sql/6_40_DNS_top_queried_domains.sql
+++ b/backends/bigquery/sql/6_40_DNS_top_queried_domains.sql
@@ -18,7 +18,7 @@ SELECT
  jsonPayload.queryname,
  COUNT(jsonPayload.queryname) AS TotalQueries
 FROM
- `[MY_DATASET_ID].[MY_PROJECT_ID].dns_googleapis_com_dns_queries`
+ `[MY_PROJECT_ID].[MY_DATASET_ID].dns_googleapis_com_dns_queries`
 WHERE
   timestamp >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
 GROUP BY


### PR DESCRIPTION
A couple of rules in the `backends/bigquery/sql` set have a `FROM` statement in the form of `[MY_DATASET_ID].[MY_PROJECT_ID]` instead of the expected `[MY_PROJECT_ID].[MY_DATASET_ID]` format.

Small fix that may help prevent a headache in the future 👍 