### PR TITLE
Fix incorrect regex

### DIFF
--- a/backends/bigquery/sql/2_02_user_added_to_privileged_group.sql
+++ b/backends/bigquery/sql/2_02_user_added_to_privileged_group.sql
@@ -34,5 +34,5 @@ WHERE
     SELECT * FROM UNNEST(JSON_QUERY_ARRAY(protopayload_auditlog.metadataJson, '$.event[0].parameter')) AS x
     WHERE
       JSON_VALUE(x, '$.name') = 'GROUP_EMAIL'
-      AND REGEXP_CONTAINS(JSON_VALUE(x, '$.value'), r'[admin|prod].*') -- Update regexp with other sensitive groups if applicable
+      AND REGEXP_CONTAINS(JSON_VALUE(x, '$.value'), r'(admin|prod).*') -- Update regexp with other sensitive groups if applicable
   )

--- a/backends/log_analytics/sql/2_02_user_added_to_privileged_group.sql
+++ b/backends/log_analytics/sql/2_02_user_added_to_privileged_group.sql
@@ -34,5 +34,5 @@ WHERE
     SELECT * FROM UNNEST(JSON_QUERY_ARRAY(proto_payload.audit_log.metadata.event[0].parameter)) AS x
     WHERE
       JSON_VALUE(x.name) = "GROUP_EMAIL"
-      AND REGEXP_CONTAINS(JSON_VALUE(x.value), r'[admin|prod].*') -- Update regexp with other sensitive groups if applicable
+      AND REGEXP_CONTAINS(JSON_VALUE(x.value), r'(admin|prod).*') -- Update regexp with other sensitive groups if applicable
   )


### PR DESCRIPTION
The regex for the `User added to privileged group` rule was using brackets instead of parantheses which doesn't have the intended effect. Fixed by changing to parantheses instead.