### PR TITLE
fix "Array cannot have a null element" dataform summary queries 

### DIFF
--- a/dataform/definitions/summary/csa_6_01_summary_hourly.sqlx
+++ b/dataform/definitions/summary/csa_6_01_summary_hourly.sqlx
@@ -39,7 +39,7 @@ SELECT
   COUNT(DISTINCT JSON_VALUE(json_payload.connection.dest_ip)) AS numDestIps,
   COUNT(DISTINCT JSON_VALUE(json_payload.connection.dest_port)) AS numDestPorts,
   ARRAY_AGG(DISTINCT JSON_VALUE(resource.labels.subnetwork_name)) AS subnetNames,
-  ARRAY_AGG(DISTINCT IF(JSON_VALUE(json_payload.reporter) = "DEST", JSON_VALUE(json_payload.dest_instance.vm_name), JSON_VALUE(json_payload.src_instance.vm_name))) as VMs,
+  ARRAY_AGG(DISTINCT IF(JSON_VALUE(json_payload.reporter) = "DEST", JSON_VALUE(json_payload.dest_instance.vm_name), JSON_VALUE(json_payload.src_instance.vm_name)) IGNORE NULLS) as VMs,
   COUNT(*) numSamples
 FROM
   ${ref("_AllLogs")}

--- a/dataform/definitions/summary/csa_6_10_summary_daily.sqlx
+++ b/dataform/definitions/summary/csa_6_10_summary_daily.sqlx
@@ -41,7 +41,7 @@ SELECT
   MIN(TIMESTAMP(REGEXP_REPLACE(JSON_VALUE(json_payload.start_time), r'\.(\d{0,6})\d+(Z)?$', '.\\1\\2'))) AS first_seen,
   MAX(TIMESTAMP(REGEXP_REPLACE(JSON_VALUE(json_payload.start_time), r'\.(\d{0,6})\d+(Z)?$', '.\\1\\2'))) AS last_seen,
   ARRAY_AGG(DISTINCT JSON_VALUE(resource.labels.subnetwork_name)) as subnetwork_names,
-  ARRAY_AGG(DISTINCT JSON_VALUE(json_payload.dest_instance.vm_name)) as vm_names,
+  ARRAY_AGG(DISTINCT JSON_VALUE(json_payload.dest_instance.vm_name) IGNORE NULLS) as vm_names,
   COUNT(*) counter
 FROM ${ref("_AllLogs")}
 WHERE


### PR DESCRIPTION
I had this error running this 2 querys (dataform/defenitions/summary):
csa_6_01_summary_hourly.sqlx:
- bigquery error: Query error: Array cannot have a null element; error in writing field VMs at [5:1]

csa_6_10_summary_daily.sqlx:
- bigquery error: Query error: Array cannot have a null element; error in writing field vm_names at [5:1]

I applied the "IGNORE NULLS" as a fix, maybe this will be useful for the community.
